### PR TITLE
startServer.sh as alias of ant start

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -482,7 +482,7 @@
     </target>
 
 	<target name="start" description="starts the server" depends="create_symlinks,stop,webcfg">
-		<exec executable="startServer.sh" />
+		<exec executable="exec.sh" />
 	</target>
 	
 	<target name="stop" description="stops the login server">

--- a/exec.sh
+++ b/exec.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd exe/linux
+
+./bin/LoginServer -- @servercommon.cfg &
+
+sleep 4
+
+./bin/TaskManager -- @servercommon.cfg

--- a/startServer.sh
+++ b/startServer.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-cd exe/linux
-
-./bin/LoginServer -- @servercommon.cfg &
-
-sleep 4
-
-./bin/TaskManager -- @servercommon.cfg
+ant start


### PR DESCRIPTION
This will allow the user to continue using startServer.sh because that's what's directed in the Terminator heading on VM3.0 but it'll just be an alias for ant start